### PR TITLE
feature(blacklist): all content is now always checked agains blacklisted terms

### DIFF
--- a/languages/en.php
+++ b/languages/en.php
@@ -10,6 +10,7 @@ $english = array(
 	'community_spam_tools:msg_limit' => 'Maximum number of sent messages over 5 minutes',
 	'community_spam_tools:msg_limit:new_user' => 'Maximum number of sent messages for new users',
 	'community_spam_tools:blacklist' => 'Comma-separated list of spam words or phrases',
+	'community_spam_tools:blacklist:desc' => 'All user profile fields and the description field of all content types will be checked for these terms. If two or more terms are found, the user gets banned.',
 );
 
 add_translation('en', $english);

--- a/views/default/plugins/community_spam_tools/settings.php
+++ b/views/default/plugins/community_spam_tools/settings.php
@@ -32,4 +32,5 @@ echo elgg_view('input/plaintext', array(
 	'name' => 'params[profile_blacklist]',
 	'value' => $blacklist,
 ));
+echo '<span class="elgg-text-help">' . elgg_echo('community_spam_tools:blacklist:desc') . '</span>';
 echo '</div>';


### PR DESCRIPTION
- All content is now checked instead of just the 'message' objects
- Checking uses the blacklist in plugin settings instead of hardcoded one
- Checking is done also when updating content instead of just on creation
